### PR TITLE
Fix Template Paths

### DIFF
--- a/tasks/main.yaml
+++ b/tasks/main.yaml
@@ -5,7 +5,7 @@
 - name: Copy pgbouncer default
   tags: pgbouncer
   template:
-    src: "roles/pgbouncer/templates/etc/default/pgbouncer"
+    src: "templates/etc/default/pgbouncer"
     dest: "/etc/default/pgbouncer"
     owner: root
     group: root
@@ -14,7 +14,7 @@
 - name: Copy pgbouncer config files
   tags: pgbouncer
   template:
-    src: "roles/pgbouncer/templates/etc/pgbouncer/{{ item }}"
+    src: "templates/etc/pgbouncer/{{ item }}"
     dest: "/etc/pgbouncer/{{ item }}"
     owner: postgres
     group: postgres


### PR DESCRIPTION
Change the paths pointing to the template directory in this role using "roles/pgbouncer/templates" to just "templates" so as to avoid having to always call the role pgbouncer when importing it to playbooks.

Signed-off-by: Jason Rogena <jasonrogena@gmail.com>
  