### PR TITLE
Allow ignoring startup parameters

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,1 +1,2 @@
 reload_not_restart: False
+ignore_startup_parameters:

--- a/templates/etc/pgbouncer/pgbouncer.ini
+++ b/templates/etc/pgbouncer/pgbouncer.ini
@@ -160,8 +160,9 @@ server_reset_query =
 ; in startup packet.  Newer JDBC versions require the
 ; extra_float_digits here.
 ;
-;ignore_startup_parameters = extra_float_digits
-
+{% if pgbouncer_ignore_startup_parameter is defined and pgbouncer_ignore_startup_parameter|length %}
+ignore_startup_parameters = {{ pgbouncer_ignore_startup_parameter }}
+{% endif %}
 ;
 ; When taking idle server into use, this query is ran first.
 ;   SELECT 1


### PR DESCRIPTION
There are some deployments where we'd want to specify which startup
parameters should be ignored. Allow for this to be done through the
variable ignore_startup_parameters.

Signed-off-by: Jason Rogena <jason@rogena.me>