### PR TITLE
Adds Support for a Custom APT Repo

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,3 +1,5 @@
+pgbouncer_version: "1.13.*"
+
 reload_not_restart: False
 ignore_startup_parameters:
 
@@ -12,3 +14,11 @@ pgbouncer_server_tls_sslmode: "verify-ca"
 
 # Contents of the TLS CA certificate the PostgreSQL database's certificate is signed using.
 pgbouncer_server_tls_ca_content: "{{ lookup('url', 'https://s3.amazonaws.com/rds-downloads/rds-ca-2019-root.pem', split_lines=false) }}"
+
+# Whether to install the apt repository with PgBouncer
+pgbouncer_install_repository: true
+pgbouncer_apt_key_id: "ACCC4CF8"
+pgbouncer_apt_key_url: "https://www.postgresql.org/media/keys/{{ pgbouncer_apt_key_id }}.asc"
+# Version of the PostgreSQL apt repository
+pgbouncer_apt_postgresql_version: 12
+pgbouncer_apt_repository: "deb http://apt.postgresql.org/pub/repos/apt/ {{ ansible_distribution_release }}-pgdg main {{ pgbouncer_apt_postgresql_version }}"

--- a/tasks/ubuntu.yml
+++ b/tasks/ubuntu.yml
@@ -1,9 +1,25 @@
 ---
+- name: Make sure the CA certificates are available
+  apt:
+    pkg: ca-certificates
+    state: present
+
+- name: Add PgBouncer repository apt-key
+  apt_key:
+    id: "{{ pgbouncer_apt_key_id }}"
+    url: "{{ pgbouncer_apt_key_url }}"
+    state: present
+  when: pgbouncer_apt_key_url and pgbouncer_apt_key_id and pgbouncer_install_repository
+
+- name: Add PgBouncer repository
+  apt_repository:
+    repo: "{{ pgbouncer_apt_repository }}"
+    state: present
+  when: pgbouncer_apt_repository | default('') != '' and pgbouncer_install_repository
+
 - name: ensure pgbouncer is installed
   apt:
-    pkg: "{{ item }}"
-    state: latest
+    pkg: "pgbouncer={{ pgbouncer_version }}"
+    state: present
     update_cache: yes
     cache_valid_time: 600
-  with_items:
-    - pgbouncer


### PR DESCRIPTION
Add support for configuring a custom APT repository as a source for
PgBouncer. Set the default repository to the postgresql.org repository.

The postgresql.org repository contains PgBouncer 1.13.0 which supports
more reliable TLS connections to PostgreSQL.

Signed-off-by: Jason Rogena <jason@rogena.me>